### PR TITLE
[LT-5260] Add support for hugging face datasets in eval

### DIFF
--- a/clarifai_model_utils/llm_eval/main.py
+++ b/clarifai_model_utils/llm_eval/main.py
@@ -5,6 +5,7 @@ from typing import Tuple, TypeVar, Union
 
 import pandas as pd
 from google.protobuf.json_format import MessageToDict
+from datasets import Dataset as HFDataset
 
 from clarifai.client.dataset import Dataset
 from clarifai.client.model import Model
@@ -265,7 +266,7 @@ class ClarifaiEvaluator():
 
   def evaluate(self,
                template: str,
-               dataset: Union[Dataset, pd.DataFrame],
+               dataset: Union[Dataset, pd.DataFrame, HFDataset],
                upload: bool = False,
                inference_parameters: dict = {},
                weights: dict = {},
@@ -281,7 +282,7 @@ class ClarifaiEvaluator():
 
     Args:
         template (str): name of defined template or path to folder contains harness config/yaml
-        dataset (Union[Dataset, pd.DataFrame]): Dataset to evaluate
+        dataset (Union[Dataset, pd.DataFrame, HFDataset]): Dataset to evaluate
         upload (bool, optional): Upload result to the platform. Defaults to False.
         inference_parameters (dict, optional): inference parameters. Defaults to {}.
         weights (dict, optional): Normalized (to 1) weights of metrics to compute average score. Defaults to {}.
@@ -314,6 +315,8 @@ class ClarifaiEvaluator():
       assert dataset_id or app_id, ValueError(
           f"`dataset_id` or `app_id` is empty when using local dataset. Please pass them to kwargs"
       )
+    elif isinstance(dataset, HFDataset):
+      df = dataset.to_pandas(batched=True)
     else:
       raise Exception
 


### PR DESCRIPTION
## Example usage

```diff
from clarifai_model_utils import ClarifaiEvaluator
from clarifai_model_utils.llm_eval.constant import JUDGE_LLMS

from clarifai.client.model import Model

+ from datasets import load_dataset
- from clarifai.client.dataset import Dataset

model = Model(model_url)

+ ds = load_dataset("stanfordnlp/coqa", split="train")
- ds = Dataset(ds_url)

evaluator = ClarifaiEvaluator(predictor=model)

out = evaluator.evaluate(
  template="llm_as_judge",
  judge_llm_url=JUDGE_LLMS.GPT3_5_TURBO,
  upload=True,
  dataset=ds,
)
print(out)
```